### PR TITLE
Added CMake Tools to Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You are free to use any development setup you want, as long as you can confortab
 
 If you don't have an IDE setup, you can follow this quick platform-independent setup:
 1. download and install [CMake](https://cmake.org/download/) (for mac users, use [brew](https://brew.sh/) instead of downloading from the website)
-2. download [VSCode](https://code.visualstudio.com/download) and install the C/C++ Extension Pack (the one from Microsoft)
+2. download [VSCode](https://code.visualstudio.com/download) and install the C/C++ Extension Pack and the CMake Tools Pack (the ones from Microsoft)
 4. clone the exercise repository `git clone --recurse-submodules https://github.com/Chris-Carvelli/game-programming-25.git` 
 5. open repository in VSCode
 6. in `Preferences->Settings`, search for `cmake path` and replace the content with the path to your CMake executable (you can find in typing `where cmake` or `which cmake` on the command line)


### PR DESCRIPTION
CMake Tools is not part of the C/C++ Extension, but seems to be required to fully setup the development environment as the CMake Tools pack includes the cmake tab.